### PR TITLE
Allow Apache to run under the same user and group as the mounted volume

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,8 +1,6 @@
 FROM php:{{ version }}-apache
 MAINTAINER Stepan Mazurov <stepan@socialengine.com>
 
-COPY bin/* /usr/local/bin/
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 	libmcrypt-dev \
     zlib1g-dev \
@@ -10,19 +8,24 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     git \
   && rm -rf /var/lib/apt/lists/*
 
-# You can use this to enable xdebug. start-apache2 script will enable xdebug 
+COPY bin/* /usr/local/bin/
+
+# Setup bare-minimum extra extensions for Laravel & others
+RUN docker-php-ext-install mbstring mcrypt zip \
+	&& docker-php-pecl-install xdebug
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php -- \
+	--install-dir=/usr/local/bin \
+	--filename=composer
+
+# You can use this to enable xdebug. start-apache2 script will enable xdebug
 # if PHP_XDEBUG is set to 1
 ENV PHP_XDEBUG 0
 ENV PHP_TIMEZONE "UTC"
 
-# Setup bare-minimum extra extensions for Laravel & others
-RUN docker-php-ext-install mbstring mcrypt zip \ 
-  && docker-php-pecl-install xdebug
-
-# Install composer
-RUN curl -sS https://getcomposer.org/installer | php -- \
-    --install-dir=/usr/local/bin \
-    --filename=composer
+# The path that will be used to make Apache run under that user
+ENV VOLUME_PATH /app/public
 
 # Setup apache
 RUN a2enmod rewrite

--- a/template/apache2.conf
+++ b/template/apache2.conf
@@ -6,8 +6,8 @@ Timeout 300
 KeepAlive On
 MaxKeepAliveRequests 100
 KeepAliveTimeout 5
-User www-data
-Group www-data
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
 HostnameLookups Off
 ErrorLog /proc/self/fd/2
 LogLevel warn

--- a/template/bin/create-user-from-directory-owner
+++ b/template/bin/create-user-from-directory-owner
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+##
+# Generate a random sixteen-character
+# string of alphabetical characters
+randname() {
+    local -x LC_ALL=C
+    tr -dc '[:lower:]' < /dev/urandom |
+        dd count=1 bs=16 2>/dev/null
+}
+
+create_user_from_directory_owner() {
+    if [ $# -ne 1 ]; then
+        echo "Creates a user (and group) from the owner of a given directory, if it doesn't exist."
+        echo "Usage: create_user_from_directory_owner <path>"
+
+        return 1
+    fi
+
+    local owner group owner_id group_id path
+    path=$1
+
+    read owner group owner_id group_id < <(stat -c '%U %G %u %g' $path)
+    if [[ $owner = UNKNOWN ]]; then
+        owner=$(randname)
+        if [[ $group = UNKNOWN ]]; then
+            group=$owner
+            addgroup --system --gid "$group_id" "$group" > /dev/null
+        fi
+        adduser --no-create-home --system --uid=$owner_id --gid=$group_id "$owner" > /dev/null
+        echo "[Apache User] Created user for uid ($owner_id), and named it '$owner'"
+    fi
+
+    sed -i "s/\${APACHE_RUN_USER}/$owner/g" /etc/apache2/apache2.conf
+    sed -i "s/\${APACHE_RUN_GROUP}/$group/g" /etc/apache2/apache2.conf
+    echo "[Apache User] Set Apache user to $owner and group to $group"
+
+    return 0
+}

--- a/template/bin/setup-container
+++ b/template/bin/setup-container
@@ -4,8 +4,13 @@ typeset script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 . "$script_dir/php5-timezone"
 . "$script_dir/php5-xdebug"
+. "$script_dir/create-user-from-directory-owner"
 
-_php_set_xdebug "${PHP_INI_DIR}" "${PHP_XDEBUG}" 
+_php_set_xdebug "${PHP_INI_DIR}" "${PHP_XDEBUG}"
 _php_set_timezone "${PHP_INI_DIR}" "${PHP_TIMEZONE}"
+
+# Set Apache user/group
+create_user_from_directory_owner "${VOLUME_PATH}"
+
 
 exec "$@"

--- a/versions/5.5/Dockerfile
+++ b/versions/5.5/Dockerfile
@@ -1,8 +1,6 @@
 FROM php:5.5-apache
 MAINTAINER Stepan Mazurov <stepan@socialengine.com>
 
-COPY bin/* /usr/local/bin/
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 	libmcrypt-dev \
     zlib1g-dev \
@@ -10,19 +8,24 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     git \
   && rm -rf /var/lib/apt/lists/*
 
-# You can use this to enable xdebug. start-apache2 script will enable xdebug 
+COPY bin/* /usr/local/bin/
+
+# Setup bare-minimum extra extensions for Laravel & others
+RUN docker-php-ext-install mbstring mcrypt zip \
+	&& docker-php-pecl-install xdebug
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php -- \
+	--install-dir=/usr/local/bin \
+	--filename=composer
+
+# You can use this to enable xdebug. start-apache2 script will enable xdebug
 # if PHP_XDEBUG is set to 1
 ENV PHP_XDEBUG 0
 ENV PHP_TIMEZONE "UTC"
 
-# Setup bare-minimum extra extensions for Laravel & others
-RUN docker-php-ext-install mbstring mcrypt zip \ 
-  && docker-php-pecl-install xdebug
-
-# Install composer
-RUN curl -sS https://getcomposer.org/installer | php -- \
-    --install-dir=/usr/local/bin \
-    --filename=composer
+# The path that will be used to make Apache run under that user
+ENV VOLUME_PATH /app/public
 
 # Setup apache
 RUN a2enmod rewrite

--- a/versions/5.5/README.md
+++ b/versions/5.5/README.md
@@ -43,6 +43,23 @@ $ docker run -e PHP_XDEBUG=1 [your image]
 
 See [example](example/) for further info. 
 
+## Check Links
+
+A lot of times, your depedant services aren't ready to go as fast as your app
+
+For that, there's a `check_docker_link` command that will check TCP to make 
+sure its up
+
+```
+Usage: check_docker_link <name> <addr> <port>
+
+# Example
+if check_docker_link "mysql" "${DB_1_PORT_3306_TCP_ADDR}" "${DB_1_PORT_3306_TCP_PORT}"; then
+    export MYSQL_HOST=${DB_1_PORT_3306_TCP_ADDR}
+    export MYSQL_PORT=${DB_1_PORT_3306_TCP_PORT}
+fi
+```
+
 [base image]: https://github.com/docker-library/php
 [5.5]: https://github.com/SocialEngine/docker-php-apache/blob/master/versions/5.5/Dockerfile
 [5.6]: https://github.com/SocialEngine/docker-php-apache/blob/master/versions/5.6/Dockerfile

--- a/versions/5.5/apache2.conf
+++ b/versions/5.5/apache2.conf
@@ -6,8 +6,8 @@ Timeout 300
 KeepAlive On
 MaxKeepAliveRequests 100
 KeepAliveTimeout 5
-User www-data
-Group www-data
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
 HostnameLookups Off
 ErrorLog /proc/self/fd/2
 LogLevel warn

--- a/versions/5.5/bin/create-user-from-directory-owner
+++ b/versions/5.5/bin/create-user-from-directory-owner
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+##
+# Generate a random sixteen-character
+# string of alphabetical characters
+randname() {
+    local -x LC_ALL=C
+    tr -dc '[:lower:]' < /dev/urandom |
+        dd count=1 bs=16 2>/dev/null
+}
+
+create_user_from_directory_owner() {
+    if [ $# -ne 1 ]; then
+        echo "Creates a user (and group) from the owner of a given directory, if it doesn't exist."
+        echo "Usage: create_user_from_directory_owner <path>"
+
+        return 1
+    fi
+
+    local owner group owner_id group_id path
+    path=$1
+
+    read owner group owner_id group_id < <(stat -c '%U %G %u %g' $path)
+    if [[ $owner = UNKNOWN ]]; then
+        owner=$(randname)
+        if [[ $group = UNKNOWN ]]; then
+            group=$owner
+            addgroup --system --gid "$group_id" "$group" > /dev/null
+        fi
+        adduser --no-create-home --system --uid=$owner_id --gid=$group_id "$owner" > /dev/null
+        echo "[Apache User] Created user for uid ($owner_id), and named it '$owner'"
+    fi
+
+    sed -i "s/\${APACHE_RUN_USER}/$owner/g" /etc/apache2/apache2.conf
+    sed -i "s/\${APACHE_RUN_GROUP}/$group/g" /etc/apache2/apache2.conf
+    echo "[Apache User] Set Apache user to $owner and group to $group"
+
+    return 0
+}

--- a/versions/5.5/bin/setup-container
+++ b/versions/5.5/bin/setup-container
@@ -4,8 +4,13 @@ typeset script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 . "$script_dir/php5-timezone"
 . "$script_dir/php5-xdebug"
+. "$script_dir/create-user-from-directory-owner"
 
-_php_set_xdebug "${PHP_INI_DIR}" "${PHP_XDEBUG}" 
+_php_set_xdebug "${PHP_INI_DIR}" "${PHP_XDEBUG}"
 _php_set_timezone "${PHP_INI_DIR}" "${PHP_TIMEZONE}"
+
+# Set Apache user/group
+create_user_from_directory_owner "${VOLUME_PATH}"
+
 
 exec "$@"

--- a/versions/5.6/Dockerfile
+++ b/versions/5.6/Dockerfile
@@ -1,8 +1,6 @@
 FROM php:5.6-apache
 MAINTAINER Stepan Mazurov <stepan@socialengine.com>
 
-COPY bin/* /usr/local/bin/
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 	libmcrypt-dev \
     zlib1g-dev \
@@ -10,19 +8,24 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     git \
   && rm -rf /var/lib/apt/lists/*
 
-# You can use this to enable xdebug. start-apache2 script will enable xdebug 
+COPY bin/* /usr/local/bin/
+
+# Setup bare-minimum extra extensions for Laravel & others
+RUN docker-php-ext-install mbstring mcrypt zip \
+	&& docker-php-pecl-install xdebug
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php -- \
+	--install-dir=/usr/local/bin \
+	--filename=composer
+
+# You can use this to enable xdebug. start-apache2 script will enable xdebug
 # if PHP_XDEBUG is set to 1
 ENV PHP_XDEBUG 0
 ENV PHP_TIMEZONE "UTC"
 
-# Setup bare-minimum extra extensions for Laravel & others
-RUN docker-php-ext-install mbstring mcrypt zip \ 
-  && docker-php-pecl-install xdebug
-
-# Install composer
-RUN curl -sS https://getcomposer.org/installer | php -- \
-    --install-dir=/usr/local/bin \
-    --filename=composer
+# The path that will be used to make Apache run under that user
+ENV VOLUME_PATH /app/public
 
 # Setup apache
 RUN a2enmod rewrite

--- a/versions/5.6/README.md
+++ b/versions/5.6/README.md
@@ -43,6 +43,23 @@ $ docker run -e PHP_XDEBUG=1 [your image]
 
 See [example](example/) for further info. 
 
+## Check Links
+
+A lot of times, your depedant services aren't ready to go as fast as your app
+
+For that, there's a `check_docker_link` command that will check TCP to make 
+sure its up
+
+```
+Usage: check_docker_link <name> <addr> <port>
+
+# Example
+if check_docker_link "mysql" "${DB_1_PORT_3306_TCP_ADDR}" "${DB_1_PORT_3306_TCP_PORT}"; then
+    export MYSQL_HOST=${DB_1_PORT_3306_TCP_ADDR}
+    export MYSQL_PORT=${DB_1_PORT_3306_TCP_PORT}
+fi
+```
+
 [base image]: https://github.com/docker-library/php
 [5.5]: https://github.com/SocialEngine/docker-php-apache/blob/master/versions/5.5/Dockerfile
 [5.6]: https://github.com/SocialEngine/docker-php-apache/blob/master/versions/5.6/Dockerfile

--- a/versions/5.6/apache2.conf
+++ b/versions/5.6/apache2.conf
@@ -6,8 +6,8 @@ Timeout 300
 KeepAlive On
 MaxKeepAliveRequests 100
 KeepAliveTimeout 5
-User www-data
-Group www-data
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
 HostnameLookups Off
 ErrorLog /proc/self/fd/2
 LogLevel warn

--- a/versions/5.6/bin/create-user-from-directory-owner
+++ b/versions/5.6/bin/create-user-from-directory-owner
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+##
+# Generate a random sixteen-character
+# string of alphabetical characters
+randname() {
+    local -x LC_ALL=C
+    tr -dc '[:lower:]' < /dev/urandom |
+        dd count=1 bs=16 2>/dev/null
+}
+
+create_user_from_directory_owner() {
+    if [ $# -ne 1 ]; then
+        echo "Creates a user (and group) from the owner of a given directory, if it doesn't exist."
+        echo "Usage: create_user_from_directory_owner <path>"
+
+        return 1
+    fi
+
+    local owner group owner_id group_id path
+    path=$1
+
+    read owner group owner_id group_id < <(stat -c '%U %G %u %g' $path)
+    if [[ $owner = UNKNOWN ]]; then
+        owner=$(randname)
+        if [[ $group = UNKNOWN ]]; then
+            group=$owner
+            addgroup --system --gid "$group_id" "$group" > /dev/null
+        fi
+        adduser --no-create-home --system --uid=$owner_id --gid=$group_id "$owner" > /dev/null
+        echo "[Apache User] Created user for uid ($owner_id), and named it '$owner'"
+    fi
+
+    sed -i "s/\${APACHE_RUN_USER}/$owner/g" /etc/apache2/apache2.conf
+    sed -i "s/\${APACHE_RUN_GROUP}/$group/g" /etc/apache2/apache2.conf
+    echo "[Apache User] Set Apache user to $owner and group to $group"
+
+    return 0
+}

--- a/versions/5.6/bin/setup-container
+++ b/versions/5.6/bin/setup-container
@@ -4,8 +4,13 @@ typeset script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 . "$script_dir/php5-timezone"
 . "$script_dir/php5-xdebug"
+. "$script_dir/create-user-from-directory-owner"
 
-_php_set_xdebug "${PHP_INI_DIR}" "${PHP_XDEBUG}" 
+_php_set_xdebug "${PHP_INI_DIR}" "${PHP_XDEBUG}"
 _php_set_timezone "${PHP_INI_DIR}" "${PHP_TIMEZONE}"
+
+# Set Apache user/group
+create_user_from_directory_owner "${VOLUME_PATH}"
+
 
 exec "$@"

--- a/versions/7.0/Dockerfile
+++ b/versions/7.0/Dockerfile
@@ -1,8 +1,6 @@
 FROM php:7.0-apache
 MAINTAINER Stepan Mazurov <stepan@socialengine.com>
 
-COPY bin/* /usr/local/bin/
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
 	libmcrypt-dev \
     zlib1g-dev \
@@ -10,19 +8,24 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     git \
   && rm -rf /var/lib/apt/lists/*
 
-# You can use this to enable xdebug. start-apache2 script will enable xdebug 
+COPY bin/* /usr/local/bin/
+
+# Setup bare-minimum extra extensions for Laravel & others
+RUN docker-php-ext-install mbstring mcrypt zip \
+	&& docker-php-pecl-install xdebug
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php -- \
+	--install-dir=/usr/local/bin \
+	--filename=composer
+
+# You can use this to enable xdebug. start-apache2 script will enable xdebug
 # if PHP_XDEBUG is set to 1
 ENV PHP_XDEBUG 0
 ENV PHP_TIMEZONE "UTC"
 
-# Setup bare-minimum extra extensions for Laravel & others
-RUN docker-php-ext-install mbstring mcrypt zip \ 
-  && docker-php-pecl-install xdebug
-
-# Install composer
-RUN curl -sS https://getcomposer.org/installer | php -- \
-    --install-dir=/usr/local/bin \
-    --filename=composer
+# The path that will be used to make Apache run under that user
+ENV VOLUME_PATH /app/public
 
 # Setup apache
 RUN a2enmod rewrite

--- a/versions/7.0/README.md
+++ b/versions/7.0/README.md
@@ -43,6 +43,23 @@ $ docker run -e PHP_XDEBUG=1 [your image]
 
 See [example](example/) for further info. 
 
+## Check Links
+
+A lot of times, your depedant services aren't ready to go as fast as your app
+
+For that, there's a `check_docker_link` command that will check TCP to make 
+sure its up
+
+```
+Usage: check_docker_link <name> <addr> <port>
+
+# Example
+if check_docker_link "mysql" "${DB_1_PORT_3306_TCP_ADDR}" "${DB_1_PORT_3306_TCP_PORT}"; then
+    export MYSQL_HOST=${DB_1_PORT_3306_TCP_ADDR}
+    export MYSQL_PORT=${DB_1_PORT_3306_TCP_PORT}
+fi
+```
+
 [base image]: https://github.com/docker-library/php
 [5.5]: https://github.com/SocialEngine/docker-php-apache/blob/master/versions/5.5/Dockerfile
 [5.6]: https://github.com/SocialEngine/docker-php-apache/blob/master/versions/5.6/Dockerfile

--- a/versions/7.0/apache2.conf
+++ b/versions/7.0/apache2.conf
@@ -6,8 +6,8 @@ Timeout 300
 KeepAlive On
 MaxKeepAliveRequests 100
 KeepAliveTimeout 5
-User www-data
-Group www-data
+User ${APACHE_RUN_USER}
+Group ${APACHE_RUN_GROUP}
 HostnameLookups Off
 ErrorLog /proc/self/fd/2
 LogLevel warn

--- a/versions/7.0/bin/create-user-from-directory-owner
+++ b/versions/7.0/bin/create-user-from-directory-owner
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+##
+# Generate a random sixteen-character
+# string of alphabetical characters
+randname() {
+    local -x LC_ALL=C
+    tr -dc '[:lower:]' < /dev/urandom |
+        dd count=1 bs=16 2>/dev/null
+}
+
+create_user_from_directory_owner() {
+    if [ $# -ne 1 ]; then
+        echo "Creates a user (and group) from the owner of a given directory, if it doesn't exist."
+        echo "Usage: create_user_from_directory_owner <path>"
+
+        return 1
+    fi
+
+    local owner group owner_id group_id path
+    path=$1
+
+    read owner group owner_id group_id < <(stat -c '%U %G %u %g' $path)
+    if [[ $owner = UNKNOWN ]]; then
+        owner=$(randname)
+        if [[ $group = UNKNOWN ]]; then
+            group=$owner
+            addgroup --system --gid "$group_id" "$group" > /dev/null
+        fi
+        adduser --no-create-home --system --uid=$owner_id --gid=$group_id "$owner" > /dev/null
+        echo "[Apache User] Created user for uid ($owner_id), and named it '$owner'"
+    fi
+
+    sed -i "s/\${APACHE_RUN_USER}/$owner/g" /etc/apache2/apache2.conf
+    sed -i "s/\${APACHE_RUN_GROUP}/$group/g" /etc/apache2/apache2.conf
+    echo "[Apache User] Set Apache user to $owner and group to $group"
+
+    return 0
+}

--- a/versions/7.0/bin/setup-container
+++ b/versions/7.0/bin/setup-container
@@ -4,8 +4,13 @@ typeset script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 . "$script_dir/php5-timezone"
 . "$script_dir/php5-xdebug"
+. "$script_dir/create-user-from-directory-owner"
 
-_php_set_xdebug "${PHP_INI_DIR}" "${PHP_XDEBUG}" 
+_php_set_xdebug "${PHP_INI_DIR}" "${PHP_XDEBUG}"
 _php_set_timezone "${PHP_INI_DIR}" "${PHP_TIMEZONE}"
+
+# Set Apache user/group
+create_user_from_directory_owner "${VOLUME_PATH}"
+
 
 exec "$@"


### PR DESCRIPTION
### What is the problem / feature ?

There are occasionally issues where Apache cannot write to mounted volumes because of permissions problems. 
### How did it get fixed / implemented ?
- Make the Apache user (and group) run under the same `uid` and `gid` as the public folder.
- Reorder `Dockerfile` so that the COPY comes later (improving the caching situation)
- Make exec in `setup-container` optional so that child images can use it
### How can someone test / see it ?
- Copy templates to the individual version by running `./update.sh`
- `cd` to one of the versions and build it
- Run the image with a mounted volume and see the `APACHE_RUN_USER` change:

```
docker run --rm -v `pwd`/example:/app/public socialengine/php-apache:5.6 env
```
